### PR TITLE
Improving error handling on repository.insertMany

### DIFF
--- a/src/Repository.ts
+++ b/src/Repository.ts
@@ -375,7 +375,7 @@ export class Repository<TD extends IDocumentClass> {
             return documents;
 
         } catch (err) {
-            if (Array.isArray(err.result.result.insertedIds)) {
+            if (Array.isArray(err.result?.result.insertedIds)) {
                 err.result.result.insertedIds.forEach((x: any, i: number) => {
                     documents[i]._id = x._id;
                 });

--- a/tests/general.test.ts
+++ b/tests/general.test.ts
@@ -120,6 +120,12 @@ describe("General Test", () => {
         }
     });
 
+    it("insert empty array of documents", async () => {
+        await assertMongoError(async () => {
+            const results = await repository1.insertMany([]);
+        }, /Invalid Operation, no operations specified/)
+    });
+
     it("insert array of documents with error", async () => {
         const newDocument = repository1.create();
         await repository1.insert(newDocument);


### PR DESCRIPTION
I'm proposing the following change to `src/Repository.ts`

### Original code:

```
 public async insertMany(documents: Array<InstanceType<TD>>, options?: IInsertManyOptions): Promise<Array<InstanceType<TD>>> {
       // ...
        try {
            const mongodbResponse = await collection.insertMany(setList, options);
            // ...
            return documents;

        } catch (err) {
            if (Array.isArray(err.result.result.insertedIds)) {
                // ...
            }
            throw Object.assign(err, friendlyErrorStack && {stack: updateStack(friendlyErrorStack, err)});
        }
    }
```
   
### Issue
In the case when `documents = []`, mongodb natively throws `Error` with message `'Invalid Operation, no operations specified'`, which is not the expected type in the if statment in the catch statment, leading to a confusing `'Cannot read property 'result' of undefined'`. My commit fixes this issue.